### PR TITLE
Fix time unit issues

### DIFF
--- a/GameFrame/Program/Application.cpp
+++ b/GameFrame/Program/Application.cpp
@@ -35,6 +35,7 @@ namespace HJUIK
 		}
 	}
 
+    // NOLINTBEGIN
 	auto Application::update(Time deltaTime) -> void {}
 
 

--- a/GameFrame/Program/Application.cpp
+++ b/GameFrame/Program/Application.cpp
@@ -35,7 +35,6 @@ namespace HJUIK
 		}
 	}
 
-    // NOLINTBEGIN
 	auto Application::update(Time deltaTime) -> void {}
 
 

--- a/GameFrame/Utilize/StopWatch.cpp
+++ b/GameFrame/Utilize/StopWatch.cpp
@@ -9,7 +9,7 @@ namespace HJUIK
 		auto StopWatch::restart() -> Time
 		{
 			const Point now								= std::chrono::steady_clock::now();
-			const std::chrono::duration<float> duration = (now - mStart);
+			const auto duration                         = (now - mStart);
 			mStart										= now;
 			const auto seconds = std::chrono::duration_cast<std::chrono::duration<float>>(duration).count();
 			return Time{seconds};


### PR DESCRIPTION
Using `duration_cast` instead of directly casting the duration count to float (which assumed the duration's unit to be seconds). The type `std::chrono::duration<float>` can be thought of as a version of `std::chrono::seconds` but with floating-point representation.